### PR TITLE
fix(windows): catch cold-boot SEH crash in RequestAsync

### DIFF
--- a/mediainterface-windows/src/native/windows/CMakeLists.txt
+++ b/mediainterface-windows/src/native/windows/CMakeLists.txt
@@ -21,6 +21,12 @@ add_library(mediainterface_winrt SHARED
 target_compile_features(mediainterface_winrt PRIVATE cxx_std_20)
 target_compile_definitions(mediainterface_winrt PRIVATE WIN32_LEAN_AND_MEAN NOMINMAX)
 
+# /EHa: asynchronous (SEH) exception handling so catch(...) intercepts
+# access violations from WinRT's RPC layer during cold-boot service init.
+if (MSVC)
+    target_compile_options(mediainterface_winrt PRIVATE /EHa)
+endif()
+
 target_include_directories(mediainterface_winrt PRIVATE
     "${JAVA_HOME}/include"
     "${JAVA_HOME}/include/win32"

--- a/mediainterface-windows/src/native/windows/bridge_query.cpp
+++ b/mediainterface-windows/src/native/windows/bridge_query.cpp
@@ -10,10 +10,14 @@ Java_org_endlesssource_mediainterface_windows_WinRtBridge_nativeGetSessionIds(JN
     trace_native(env, "nativeGetSessionIds enter");
     try {
         trace_native(env, "nativeGetSessionIds requesting manager");
-        auto manager = GlobalSystemMediaTransportControlsSessionManager::RequestAsync().get();
+        auto manager = request_manager_safe(env);
+        if (!manager.has_value()) {
+            trace_native(env, "nativeGetSessionIds manager unavailable");
+            return new_string_array(env, {});
+        }
         std::vector<std::string> ids;
         std::unordered_set<std::string> seen;
-        for (auto const& session : manager.GetSessions()) {
+        for (auto const& session : manager.value().GetSessions()) {
             std::string id = to_string(session.SourceAppUserModelId());
             if (id.empty()) {
                 continue;

--- a/mediainterface-windows/src/native/windows/bridge_shared.h
+++ b/mediainterface-windows/src/native/windows/bridge_shared.h
@@ -39,4 +39,6 @@ void trace_native(JNIEnv* env, const std::string& message);
 void trace_hresult(JNIEnv* env, const char* context, const hresult_error& e);
 int64_t ticks_to_millis(int64_t ticks);
 int64_t millis_to_ticks(int64_t millis);
+// Wraps RequestAsync().get() with retry and SEH-safe catch for cold-boot AVs.
+std::optional<GlobalSystemMediaTransportControlsSessionManager> request_manager_safe(JNIEnv* env);
 std::optional<GlobalSystemMediaTransportControlsSession> find_session(const std::string& sessionId, JNIEnv* env = nullptr);


### PR DESCRIPTION
On the first launch after a PC restart, the SMTC service RPC endpoint may not be fully initialised. RequestAsync().get() can throw a native access violation (0xC0000005) from inside WinRT's COM proxy — a Windows Structured Exception, not an HRESULT — which bypasses all C++ catch blocks under the default /EHsc model and kills the process.

- Add /EHa to CMakeLists so catch(...) intercepts SEH faults
- Extract request_manager_safe() with up to 3 retries (750ms apart) covering both nativeGetSessionIds and find_session call sites
- Reproducible specifically in Minecraft mod contexts due to earlier JVM startup touching native code before the SMTC service is ready

Co-Authored-By: Claude Sonnet 4.6.
Closes #3.