### PR TITLE
fix(windows): handle cold-boot SEH crashes in WinRT RequestAsync

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -193,7 +193,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          generate_release_notes: true
           files: |
             mediainterface-core/build/libs/*.jar
             mediainterface-linux/build/libs/*.jar


### PR DESCRIPTION
## Changes

- **bridge_seh.cpp** (new): Implements `smtc_try_request_manager()` that executes `RequestAsync().get()` on a dedicated Win32 thread with `__try/__except` to catch cold-boot access violations (0xC0000005) in WinRT's COM proxy layer

- **bridge_shared.cpp**: Adds `request_manager_safe()` wrapper with up to 3 retry attempts and 750ms delays; uses atomic flag to skip thread overhead after first successful call

- **bridge_shared.h**: Declares new helper functions `smtc_try_request_manager()` and `request_manager_safe()`

- **bridge_query.cpp**: Updates to use `request_manager_safe()` instead of direct `RequestAsync().get()` call

- **CMakeLists.txt**: 
  - Adds bridge_seh.cpp to build sources
  - Configures `/EHa` (asynchronous SEH) exception handling to enable `__try/__except` blocks

- **publish.yml**: Removes `generate_release_notes: true` from release workflow

## Rationale

On first launch after reboot, WinRT activation broker may not have finished factory initialization, causing crashes. Running RequestAsync on a plain CreateThread thread (without JVM exception frames) allows `__try/__except` to reliably catch the AV.