### PR TITLE
ci: skip updating release description when uploading artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -193,7 +193,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          generate_release_notes: true
           files: |
             mediainterface-core/build/libs/*.jar
             mediainterface-linux/build/libs/*.jar


### PR DESCRIPTION
## Changes

Removes `generate_release_notes: true` from the `softprops/action-gh-release` step in the publish workflow.

## Rationale

Without this flag (which defaults to `false`), the action only uploads the jar files to the release without overwriting the release description.